### PR TITLE
Scrum 164 failed button

### DIFF
--- a/src/assets/icons/arrow-left.svg
+++ b/src/assets/icons/arrow-left.svg
@@ -1,0 +1,12 @@
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <g clip-path="url(#clip0_4548_5921)">
+        <path d="M4.16699 10H15.8337" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+        <path d="M4.16699 10L9.16699 15" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+        <path d="M4.16699 10L9.16699 5" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+    </g>
+    <defs>
+        <clipPath id="clip0_4548_5921">
+            <rect width="20" height="20" fill="white"/>
+        </clipPath>
+    </defs>
+</svg>

--- a/src/pages/OrderDetails/components/BottomNavigationBar/index.tsx
+++ b/src/pages/OrderDetails/components/BottomNavigationBar/index.tsx
@@ -1,0 +1,37 @@
+import { FC } from 'react';
+
+import { t } from 'i18next';
+
+import ArrowLeft from '@/assets/icons/arrow-left.svg';
+import Button from '@/components/Button';
+import {
+  BottomNavigation,
+  IconWrapper,
+  navigateStyles,
+  RightArrow,
+} from '@/pages/OrderDetails/styles';
+
+interface BottomBarProps {
+  openNavigateModal: () => void;
+}
+
+const BottomNavigationBar: FC<BottomBarProps> = ({ openNavigateModal }) => {
+  return (
+    <BottomNavigation>
+      <IconWrapper>
+        <img src={ArrowLeft} alt={t('orderDetails.prev')} />
+      </IconWrapper>
+      <Button
+        label={t('orderDetails.navigate')}
+        variant='outlined'
+        sx={navigateStyles}
+        onClick={openNavigateModal}
+      />
+      <IconWrapper>
+        <RightArrow src={ArrowLeft} alt={t('orderDetails.next')} />
+      </IconWrapper>
+    </BottomNavigation>
+  );
+};
+
+export default BottomNavigationBar;

--- a/src/pages/OrderDetails/components/InformCustomer/index.tsx
+++ b/src/pages/OrderDetails/components/InformCustomer/index.tsx
@@ -1,0 +1,16 @@
+import { FC } from 'react';
+
+import { Typography } from '@mui/material';
+import { t } from 'i18next';
+
+import { InformCustomerWrapper } from './styles';
+
+const InformCustomer: FC = () => {
+  return (
+    <InformCustomerWrapper>
+      <Typography>{t('orderDetails.inform')}</Typography>
+    </InformCustomerWrapper>
+  );
+};
+
+export default InformCustomer;

--- a/src/pages/OrderDetails/components/InformCustomer/styles.ts
+++ b/src/pages/OrderDetails/components/InformCustomer/styles.ts
@@ -1,0 +1,14 @@
+import styled from 'styled-components';
+
+import { COLORS } from '@/constants/colors';
+
+export const InformCustomerWrapper = styled.div`
+  box-sizing: border-box;
+  width: 100%;
+  padding: 10px;
+  background-color: ${COLORS.status.atRisk.bg};
+  border: 1px solid ${COLORS.status.atRisk.text};
+  border-radius: 6px;
+  color: ${COLORS.status.atRisk.text};
+  margin-bottom: 8px;
+`;

--- a/src/pages/OrderDetails/components/InformModal/index.tsx
+++ b/src/pages/OrderDetails/components/InformModal/index.tsx
@@ -1,0 +1,45 @@
+import { FC } from 'react';
+
+import { t } from 'i18next';
+
+import Button from '@/components/Button';
+import Modal from '@/components/Modal';
+
+interface ModalProps {
+  open: boolean;
+  handleInformCustomer: () => void;
+  handleCloseModal: () => void;
+}
+
+const InformModal: FC<ModalProps> = ({
+  open,
+  handleInformCustomer,
+  handleCloseModal,
+}) => {
+  return (
+    <Modal
+      open={open}
+      title={t('orderDetails.modal.title')}
+      description={t('orderDetails.modal.description')}
+      onClose={handleCloseModal}
+      actions={
+        <>
+          <Button
+            fullWidth
+            onClick={handleCloseModal}
+            variant='text'
+            label={t('orderDetails.modal.cancel')}
+          />
+          <Button
+            fullWidth
+            onClick={handleInformCustomer}
+            variant='contained'
+            label={t('orderDetails.modal.okay')}
+          />
+        </>
+      }
+    />
+  );
+};
+
+export default InformModal;

--- a/src/pages/OrderDetails/components/styles.ts
+++ b/src/pages/OrderDetails/components/styles.ts
@@ -21,7 +21,7 @@ export const CustomerWrapper = styled.div`
   border: 1px solid ${COLORS.schemes.outlineVariant};
   border-radius: 8px;
   padding: 10px;
-  margin-bottom: 14px;
+  margin-bottom: 12px;
   justify-content: space-between;
   position: relative;
 `;
@@ -29,6 +29,7 @@ export const CustomerWrapper = styled.div`
 export const StyledHeading = styled(Typography)`
   font-size: ${FONT.fontSize.mediumPlus}px !important;
   color: ${COLORS.schemes.secondary}!important;
+  margin-bottom: 12px !important;
 `;
 
 export const CollectionHeading = styled(Typography)`

--- a/src/pages/OrderDetails/index.tsx
+++ b/src/pages/OrderDetails/index.tsx
@@ -4,6 +4,7 @@ import { t } from 'i18next';
 import { useNavigate, useParams } from 'react-router-dom';
 import { toast } from 'react-toastify';
 
+import BottomNavigationBar from './components/BottomNavigationBar';
 import CollectioInformation from './components/CollectionInformation';
 import CustomerInformation from './components/CustomerInformation';
 import DepartureInformation from './components/DepartureInformation';
@@ -12,23 +13,21 @@ import DispatcherNote from './components/DispatcherNote';
 import InformCustomer from './components/InformCustomer';
 import InformModal from './components/InformModal';
 import {
-  BottomNavigation,
   ButtonsWrapper,
   customerInformedStyles,
   failedButtonStyles,
-  IconWrapper,
-  navigateStyles,
   OrderDetailsWrapper,
-  RightArrow,
 } from './styles';
 
-import ArrowLeft from '@/assets/icons/arrow-left.svg';
 import Button from '@/components/Button';
 import Header from '@/components/Header';
+import NavigateButtonModal from '@/components/NavigateButtonModal';
 
 const OrderDetails: FC = () => {
   const [isCustomerInformed, setIsCustomerInformed] = useState<boolean>(false);
   const [isModalOpened, setIsModalOpened] = useState<boolean>(false);
+  const [isNavigateModalOpened, setIsNavigateModalOpened] =
+    useState<boolean>(false);
   const { id } = useParams();
   const navigate = useNavigate();
   const testData = {
@@ -51,11 +50,7 @@ const OrderDetails: FC = () => {
   const handleInformCustomer = (): void => {
     setIsModalOpened(false);
     setIsCustomerInformed(true);
-    toast.success('Customer Informed!');
-  };
-
-  const handleCloseModal = (): void => {
-    setIsModalOpened(false);
+    toast.success(t('orderDetails.informed'));
   };
 
   return (
@@ -63,7 +58,11 @@ const OrderDetails: FC = () => {
       <InformModal
         open={isModalOpened}
         handleInformCustomer={handleInformCustomer}
-        handleCloseModal={handleCloseModal}
+        handleCloseModal={() => setIsModalOpened(false)}
+      />
+      <NavigateButtonModal
+        open={isNavigateModalOpened}
+        handleClose={() => setIsNavigateModalOpened(false)}
       />
       <Header hasBackIcon pageName={`${t('orders.orderNo')} ${id}`} />
       <ButtonsWrapper>
@@ -112,15 +111,9 @@ const OrderDetails: FC = () => {
         dispatcherPhone={testData.dispatcherPhone}
       />
       {testData.note && <DispatcherNote note={testData.note} />}
-      <BottomNavigation>
-        <IconWrapper>
-          <img src={ArrowLeft} alt={t('orderDetails.prev')} />
-        </IconWrapper>
-        <Button label='Navigate' variant='outlined' sx={navigateStyles} />
-        <IconWrapper>
-          <RightArrow src={ArrowLeft} alt='orderDetails.next' />
-        </IconWrapper>
-      </BottomNavigation>
+      <BottomNavigationBar
+        openNavigateModal={() => setIsNavigateModalOpened(true)}
+      />
     </OrderDetailsWrapper>
   );
 };

--- a/src/pages/OrderDetails/index.tsx
+++ b/src/pages/OrderDetails/index.tsx
@@ -1,20 +1,36 @@
-import { FC } from 'react';
+import { FC, useState } from 'react';
 
 import { t } from 'i18next';
-import { useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
+import { toast } from 'react-toastify';
 
 import CollectioInformation from './components/CollectionInformation';
 import CustomerInformation from './components/CustomerInformation';
 import DepartureInformation from './components/DepartureInformation';
 import DispatcherInformation from './components/DispatcherInformation';
 import DispatcherNote from './components/DispatcherNote';
-import { OrderDetailsWrapper } from './styles';
+import InformCustomer from './components/InformCustomer';
+import InformModal from './components/InformModal';
+import {
+  BottomNavigation,
+  ButtonsWrapper,
+  customerInformedStyles,
+  failedButtonStyles,
+  IconWrapper,
+  navigateStyles,
+  OrderDetailsWrapper,
+  RightArrow,
+} from './styles';
 
+import ArrowLeft from '@/assets/icons/arrow-left.svg';
+import Button from '@/components/Button';
 import Header from '@/components/Header';
 
 const OrderDetails: FC = () => {
+  const [isCustomerInformed, setIsCustomerInformed] = useState<boolean>(false);
+  const [isModalOpened, setIsModalOpened] = useState<boolean>(false);
   const { id } = useParams();
-
+  const navigate = useNavigate();
   const testData = {
     dispatcherName: 'Aleksa',
     dispatcherPhone: '+49015730000',
@@ -32,9 +48,48 @@ const OrderDetails: FC = () => {
     collectionAddress: 'Berlin, Adlerstraße 7',
   };
 
+  const handleInformCustomer = (): void => {
+    setIsModalOpened(false);
+    setIsCustomerInformed(true);
+    toast.success('Customer Informed!');
+  };
+
+  const handleCloseModal = (): void => {
+    setIsModalOpened(false);
+  };
+
   return (
     <OrderDetailsWrapper>
+      <InformModal
+        open={isModalOpened}
+        handleInformCustomer={handleInformCustomer}
+        handleCloseModal={handleCloseModal}
+      />
       <Header hasBackIcon pageName={`${t('orders.orderNo')} ${id}`} />
+      <ButtonsWrapper>
+        <Button
+          variant='outlined'
+          label='orderDetails.failed'
+          sx={failedButtonStyles}
+          onClick={() => navigate('/app/map/failed')}
+        />
+        {!isCustomerInformed ? (
+          <Button
+            variant='contained'
+            label='orderDetails.customerInformed'
+            sx={customerInformedStyles}
+            onClick={() => setIsModalOpened(true)}
+          />
+        ) : (
+          <Button
+            variant='contained'
+            label='orderDetails.pickup'
+            sx={customerInformedStyles}
+            onClick={() => navigate('/app/pre-arrival')}
+          />
+        )}
+      </ButtonsWrapper>
+      <InformCustomer />
       <CollectioInformation
         collectionDate={testData.collectionDate}
         collectionTimeSlot={testData.collectionTimeSlot}
@@ -57,6 +112,15 @@ const OrderDetails: FC = () => {
         dispatcherPhone={testData.dispatcherPhone}
       />
       {testData.note && <DispatcherNote note={testData.note} />}
+      <BottomNavigation>
+        <IconWrapper>
+          <img src={ArrowLeft} alt={t('orderDetails.prev')} />
+        </IconWrapper>
+        <Button label='Navigate' variant='outlined' sx={navigateStyles} />
+        <IconWrapper>
+          <RightArrow src={ArrowLeft} alt='orderDetails.next' />
+        </IconWrapper>
+      </BottomNavigation>
     </OrderDetailsWrapper>
   );
 };

--- a/src/pages/OrderDetails/styles.ts
+++ b/src/pages/OrderDetails/styles.ts
@@ -1,5 +1,64 @@
+import { SxProps, Theme } from '@mui/material';
 import styled from 'styled-components';
+
+import { COLORS } from '@/constants/colors';
+import { FONT } from '@/constants/font';
 
 export const OrderDetailsWrapper = styled.div`
   padding: 80px 16px 120px 16px;
+`;
+export const ButtonsWrapper = styled.div`
+  display: flex;
+  flex-flow: row wrap;
+  justify-content: space-between;
+  margin-top: 12px;
+  margin-bottom: 14px;
+`;
+
+export const failedButtonStyles: SxProps<Theme> = {
+  color: COLORS.status.icons.failed,
+  border: `1px solid ${COLORS.status.icons.failed}`,
+  height: '40px',
+  width: '183px',
+  borderRadius: '8px',
+  padding: '10px 16px',
+  marginBottom: '14px',
+  textTransform: 'capitalize',
+};
+
+export const customerInformedStyles: SxProps<Theme> = {
+  height: '40px',
+  width: '183px',
+  borderRadius: '8px',
+  padding: '10px 16px',
+};
+
+export const navigateStyles: SxProps<Theme> = {
+  textTransform: 'capitalize',
+  flexGrow: 3,
+  color: COLORS.purple,
+  fontWeight: FONT.fontWeight.large,
+  border: `2px solid ${COLORS.purple}`,
+};
+
+export const BottomNavigation = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 14px 0;
+  gap: 16px;
+`;
+
+export const IconWrapper = styled.div`
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  background-color: ${COLORS.purple};
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
+export const RightArrow = styled.img`
+  transform: rotate(180deg);
 `;

--- a/src/utils/i18n.ts
+++ b/src/utils/i18n.ts
@@ -238,6 +238,8 @@ const resources = {
         prev: 'Select previous order',
         next: 'Select next order',
         inform: 'You must inform the customer 2 hours before pick up the order',
+        navigate: 'Navigate',
+        informed: 'Customer Informed!',
       },
 
       routes: {

--- a/src/utils/i18n.ts
+++ b/src/utils/i18n.ts
@@ -213,6 +213,7 @@ const resources = {
         collectionDate: 'Collection date',
         collectionAddress: 'Collection address',
         customerInformation: 'Customer Information',
+        customerInformed: 'Customer Informed',
         customerName: 'Customer name',
         note: 'Note from dispatcher',
         date: 'Date',
@@ -221,11 +222,24 @@ const resources = {
         departureInfo: 'Departure information',
         dispatcherInfo: 'Dispatcher Information',
         dispatcherName: 'Dispatcher Name',
+        failed: 'Failed',
         luggageSize: 'Luggage Size',
         timeSlot: 'Time slot',
         phone: 'Phone',
+        pickup: 'Pick up the Order',
         weight: 'Weight',
+        modal: {
+          title: 'Important',
+          description:
+            'You must inform the customer 2 hours before pick up the order',
+          cancel: 'Cancel',
+          okay: 'Okay',
+        },
+        prev: 'Select previous order',
+        next: 'Select next order',
+        inform: 'You must inform the customer 2 hours before pick up the order',
       },
+
       routes: {
         route: 'Route',
         routes: 'Routes',


### PR DESCRIPTION
## Describe your changes

- I added `failed` and `customer informed` buttons with popups
- Added warning for driver that he has to inform driver 2 hours before pick up
- Added navigation bar in bottom for selecting other orders 
- Added `navigate` button that opens modal which leads driver to google maps

## Issue ticket code (and/or) and link

- [SCRUM-164: Failed button](https://codecraftersintership.atlassian.net/browse/SCRUM-164)

### **General**
<img width="331" alt="Screenshot 2024-12-23 at 00 06 30" src="https://github.com/user-attachments/assets/50b6bb86-9a17-44c9-84bc-4f3ce013f2e0" />
<img width="324" alt="Screenshot 2024-12-23 at 00 06 50" src="https://github.com/user-attachments/assets/23718144-b095-44d8-bfab-900ecdf89538" />
<img width="330" alt="Screenshot 2024-12-23 at 00 06 43" src="https://github.com/user-attachments/assets/d31ce631-ad5c-4736-b3cd-e5af2a55e2fb" />



- [x] Assigned myself to the PR
- [x] Assigned the appropriate labels to the PR
- [x] Assigned the appropriate reviewers to the PR
- [x] Updated the documentation
- [x] Performed a self-review of my code
- [x] Types for input and output parameters
- [x] Don't have "any" on my code
- [x] Used the try/catch pattern for error handling
- [x] Don't have magic numbers
- [x] Compare only with constants not with strings
- [x] No ternary operator inside the ternary operator
- [x] Don't have commented code
- [x] no links in the code, env links should be in env file (for example: server url), constant links (for example default avatar URL) should be in constant file.
- [x] Used camelCase for variables and functions
- [x] Date and time formats are on the constants
- [x] Functions are public only if it's used outside the class
- [ ] No hardcoded values
- [ ] covered by tests
- [x] Check your commit messages meet the [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/).

### Frontend

- [x] Components and business logic are separated
- [x] Colors, Font Size, and Font Name is on the theme or in the constants
- [x] No text in the components, use i18n approach
- [x] No inline styles
- [x] Imports are absolute
- [x] Attach a screenshot if PR has visual changes.
