### PR TITLE
SCRUM-192-fix-bottom-bar-after-login

### DIFF
--- a/src/pages/MainPage/components/Tab/styles.ts
+++ b/src/pages/MainPage/components/Tab/styles.ts
@@ -14,7 +14,7 @@ export const TabIcon = styled.div`
     transform: translateY(-39px);
   }
   &.active img {
-    filter: brightness(0) invert(1);
+    filter: brightness(0) invert(1) brightness(1.2);
     transform: scale(${IconScale});
   }
   position: relative;
@@ -29,10 +29,6 @@ export const TabIcon = styled.div`
   img {
     width: 24px;
     height: 24px;
-  }
-
-  &.active img {
-    filter: brightness(1.2);
   }
 `;
 

--- a/src/pages/VerificationPage/useVerification.ts
+++ b/src/pages/VerificationPage/useVerification.ts
@@ -86,7 +86,7 @@ const useVerification = (
         setOtp('');
         setIsLocked(true);
         await verifyCode(otp, email)(dispatch);
-        navigate('/app/orders');
+        navigate('/app/routes');
       } else {
         toast.error(t('verification.otpInvalid'));
       }

--- a/src/utils/pageUtils.ts
+++ b/src/utils/pageUtils.ts
@@ -1,6 +1,6 @@
 import { PAGE_NUMBER_MAP } from '@/constants/pageNumbers';
 
-const defaultPage = 2;
+const defaultPage = 1;
 
 export const getPageFromUrl = (): number => {
   const currentPath = window.location.pathname;


### PR DESCRIPTION
## Describe your changes

- Made active icon in bottom bar white
- When driver successfully logins, he is redirected to routes page instead of orders (acceptance criteria)

## Issue ticket code (and/or) and link

- [SCRUM-192-fix-bottom-bar-after-login](https://codecraftersintership.atlassian.net/browse/SCRUM-192)

### **General**
<img width="539" alt="Screenshot 2024-12-29 at 18 54 20" src="https://github.com/user-attachments/assets/06563bfe-bfb3-465f-9520-638f420883a9" />

- [x] Assigned myself to the PR
- [x] Assigned the appropriate labels to the PR
- [x] Assigned the appropriate reviewers to the PR
- [x] Updated the documentation
- [x] Performed a self-review of my code
- [x] Types for input and output parameters
- [x] Don't have "any" on my code
- [x] Used the try/catch pattern for error handling
- [x] Don't have magic numbers
- [x] Compare only with constants not with strings
- [x] No ternary operator inside the ternary operator
- [x] Don't have commented code
- [x] no links in the code, env links should be in env file (for example: server url), constant links (for example default avatar URL) should be in constant file.
- [x] Used camelCase for variables and functions
- [x] Date and time formats are on the constants
- [x] Functions are public only if it's used outside the class
- [x] No hardcoded values
- [ ] covered by tests
- [x] Check your commit messages meet the [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/).

### Frontend

- [x] Components and business logic are separated
- [x] Colors, Font Size, and Font Name is on the theme or in the constants
- [x] No text in the components, use i18n approach
- [x] No inline styles
- [x] Imports are absolute
- [x] Attach a screenshot if PR has visual changes.
