### PR TITLE
fix: fixed paddings, made prohibited items image responsive, fixed se…

### DIFF
--- a/src/pages/PickUpTheOrder/BaggageCheck/CustomerConfirmation/components/ActionBtns/styles.ts
+++ b/src/pages/PickUpTheOrder/BaggageCheck/CustomerConfirmation/components/ActionBtns/styles.ts
@@ -8,6 +8,7 @@ export const actionBtnsContainer: SxProps<Theme> = {
   display: 'flex',
   justifyContent: 'space-between',
   margin: '0 auto',
+  paddingBottom: '160px',
 };
 
 export const buttonStyles: SxProps<Theme> = {

--- a/src/pages/PickUpTheOrder/BaggageCheck/ProhibitedItemsPage/components/ActionBtns/styles.ts
+++ b/src/pages/PickUpTheOrder/BaggageCheck/ProhibitedItemsPage/components/ActionBtns/styles.ts
@@ -8,6 +8,7 @@ export const actionBtnsContainer: SxProps<Theme> = {
   display: 'flex',
   justifyContent: 'space-between',
   margin: '0 auto',
+  paddingBottom: '160px',
 };
 
 export const buttonStyles: SxProps<Theme> = {

--- a/src/pages/PickUpTheOrder/BaggageCheck/ProhibitedItemsPage/components/ItemsBlock/styles.ts
+++ b/src/pages/PickUpTheOrder/BaggageCheck/ProhibitedItemsPage/components/ItemsBlock/styles.ts
@@ -5,6 +5,9 @@ import { FONT } from '@/constants/font';
 
 export const itemsBlock: SxProps<Theme> = {
   marginTop: '87px',
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
 };
 
 export const importantBox: SxProps<Theme> = {
@@ -33,4 +36,5 @@ export const importantText: SxProps<Theme> = {
 
 export const prohibitedItemsImage: React.CSSProperties = {
   marginBottom: '20px',
+  width: '100%',
 };

--- a/src/routes/RestrictedRoute.tsx
+++ b/src/routes/RestrictedRoute.tsx
@@ -12,7 +12,7 @@ const RestrictedRoute: React.FC<RestrictedRouteProps> = ({ children }) => {
   const { isAuthenticated, role } = useAppSelector((state) => state.auth);
 
   if (isAuthenticated && role === 'driver') {
-    return <Navigate to='/app/orders' />;
+    return <Navigate to='/app/routes' />;
   }
 
   return children;


### PR DESCRIPTION
…lected bottom bar icon when clearing url

## Describe your changes

- added bottom-padding on customerConfirmation page
- added bottom-padding on ProhibitedItems page
- made image responsive and centered on ProhibitedItems page
- fixed routes after clearing url.

## Issue ticket code (and/or) and link

- [Link to JIRA ticket](https://codecraftersintership.atlassian.net/browse/SCRUM-265)

### **General**
<img width="360" alt="Screenshot 2025-01-03 at 13 02 39" src="https://github.com/user-attachments/assets/f9f865ea-75cd-4604-962f-35693e6d67fb" />
<img width="360" alt="Screenshot 2025-01-03 at 13 03 12" src="https://github.com/user-attachments/assets/82600147-aa3b-4903-bcc6-c1797b869e5b" />

- [x] Assigned myself to the PR
- [x] Assigned the appropriate labels to the PR
- [x] Assigned the appropriate reviewers to the PR
- [x] Updated the documentation
- [x] Performed a self-review of my code
- [x] Types for input and output parameters
- [x] Don't have "any" on my code
- [x] Used the try/catch pattern for error handling
- [ ] Don't have magic numbers
- [x] Compare only with constants not with strings
- [x] No ternary operator inside the ternary operator
- [x] Don't have commented code
- [x] no links in the code, env links should be in env file (for example: server url), constant links (for example default avatar URL) should be in constant file.
- [x] Used camelCase for variables and functions
- [x] Date and time formats are on the constants
- [x] Functions are public only if it's used outside the class
- [x] No hardcoded values
- [ ] covered by tests
- [x] Check your commit messages meet the [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/).

### Frontend

- [x] Components and business logic are separated
- [x] Colors, Font Size, and Font Name is on the theme or in the constants
- [x] No text in the components, use i18n approach
- [x] No inline styles
- [x] Imports are absolute
- [x] Attach a screenshot if PR has visual changes.
